### PR TITLE
fix: add dialog service to container

### DIFF
--- a/MvvmLight/ViewModel/ViewModelLocator.cs
+++ b/MvvmLight/ViewModel/ViewModelLocator.cs
@@ -38,8 +38,7 @@ namespace MvvmLight.ViewModel
             {
                 SimpleIoc.Default.Register<IDataService, DataService>();
             }
-            // Did try to manual register DialogService below - but it is not possible because of multiple constructs with no default constructor annotation
-            // SimpleIoc.Default.Register<IDialogService, DialogService>();
+            SimpleIoc.Default.Register<IDialogService>(() => new DialogService());
             SimpleIoc.Default.Register<MainViewModel>();
         }
 


### PR DESCRIPTION
The IoC container used in MVVMLight can take a factory, thus the dialog service can be defined in the container even though it has no default constructor.